### PR TITLE
設定すべきパラメータが誤っていたため修正

### DIFF
--- a/deaggregate/main.go
+++ b/deaggregate/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go/aws"
@@ -19,7 +20,7 @@ func handle(e events.KinesisEvent) error {
 			ApproximateArrivalTimestamp: aws.Time(r.Kinesis.ApproximateArrivalTimestamp.UTC()),
 			Data:                        r.Kinesis.Data,
 			EncryptionType:              &r.Kinesis.EncryptionType,
-			PartitionKey:                &r.Kinesis.EncryptionType,
+			PartitionKey:                &r.Kinesis.PartitionKey,
 			SequenceNumber:              &r.Kinesis.SequenceNumber,
 		})
 	}


### PR DESCRIPTION
[こちらの記事](https://future-architect.github.io/articles/20200727/#DeAggregate-awslabs-kinesis-aggregation) を参考にしながら kinesis の deaggregation 処理を書いていたところ、PartitionKey が設定されるべき部分に EncryptionType が設定されていました。

https://github.com/ma91n/go-kinesis-aggr-example/blob/11f531f04abcb3895ccec89a5693e6f68de760ee/deaggregate/main.go#L22

このまま実行すると、kinesis のシャードを識別するために利用する Key として EncryptionType が格納されるため想定された挙動にならず、レコードが正しく取得できないというリスクがあると考えられます。